### PR TITLE
Suppress "No url found" warning for 0 byte entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 *cookies.txt
 .tox/
+build/
+dist/

--- a/humblebundle_downloader/download_library.py
+++ b/humblebundle_downloader/download_library.py
@@ -248,9 +248,10 @@ class DownloadLibrary:
                 try:
                     url = file_type['url']['web']
                 except KeyError:
-                    logger.info("No url found: {bundle_title}/{product_title}"
-                                .format(bundle_title=bundle_title,
-                                        product_title=product_title))
+                    if file_type.get("human_size") != "0 bytes":
+                        logger.info("No url found: {bundle_title}/{product_title}"
+                                    .format(bundle_title=bundle_title,
+                                            product_title=product_title))
                     continue
 
                 url_filename = url.split('?')[0].split('/')[-1]


### PR DESCRIPTION
This commit suppresses the "No url found" warning for entries
which contain a "human_size" field set to "0 bytes".

When downloading a product, occasionally an entry in the
"download_struct" won't have a viable URL to download.
In every case I observed, this was harmless; the entry
was extra information, like a link to a web page where
you could download the soundtrack for free ("World Of Goo"),
or a link to a help page on which APK to choose ("Costume Quest"),
or some sort of... Javascript soundtrack player? ("Dustforce").

Also, in every case I observed, the entry in the "download_struct"
contained a "human_size" field set to the exact string "0 bytes".
This seems like a hint in the JSON blob saying: yeah, this entry
doesn't have anything for you to download, you can ignore it.

It's a little worrying to the casual user of the tool when it prints
these error messages.  But it seems like it's harmless.  So let's
suppress these error messages when "human_size" is "0 bytes".